### PR TITLE
removeProductFromCart関数の不具合修正

### DIFF
--- a/src/contexts/ShoppingCartContext/reducers.ts
+++ b/src/contexts/ShoppingCartContext/reducers.ts
@@ -34,7 +34,9 @@ const removeProductFromCart = (productId: number, state: Product[]) => {
 
   state.splice(removedItemIndex, 1)
 
-  return [...state]
+  const newState = [...state];
+  newState.splice(removedItemIndex, 1);
+  return newState;
 }
 
 /**

--- a/src/contexts/ShoppingCartContext/reducers.ts
+++ b/src/contexts/ShoppingCartContext/reducers.ts
@@ -34,9 +34,9 @@ const removeProductFromCart = (productId: number, state: Product[]) => {
 
   state.splice(removedItemIndex, 1)
 
-  const newState = [...state];
-  newState.splice(removedItemIndex, 1);
-  return newState;
+  const newState = [...state]
+  newState.splice(removedItemIndex, 1)
+  return newState
 }
 
 /**


### PR DESCRIPTION
<!--

外部の貢献者の方へ

いただいたPRのすべての著作権は著者（手島拓也、吉田健人、高林佳稀）に帰属します。
そのことに同意いただける場合のみPRを作成してください。

チェックリストについては、書籍の制作管理上必要なので削除せずにそのまま残してください。

-->


## 概要
yarn devで実行した際にカートにいれた商品を削除すると、カートに入っているすべての商品が削除されてしまいます。
原因は、removeProductFromCartの中でstateを更新しているからです。
yarn devで実行した環境では、removeProductFromCartが2回実行されます。
1回目の実行では期待された動作をしますが、2回目の実行時、
```
const removedItemIndex = state.findIndex((item) => item.id === productId);
```
が-1を返すため、
```
state.splice(removedItemIndex, 1);
```
によって、stateの中身がすべて削除されてしまいます。
stateを更新しないよう修正いたしました。

## チェックリスト

- [ ] 本には必要な修正を反映済か？
- [ ] 追加すべきテストをいれたか？
- [ ] READMEは必要な更新をしたか？

